### PR TITLE
Delegerer automatisk avvisning av vedtaksperiode til en dedikert komm…

### DIFF
--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
@@ -35,7 +35,7 @@ import no.nav.helse.modell.utbetaling.Utbetalingtype.Companion.values
 import no.nav.helse.modell.vedtak.snapshot.SpeilSnapshotRestClient
 import no.nav.helse.modell.vedtaksperiode.Inntektskilde
 import no.nav.helse.modell.vedtaksperiode.Periodetype
-import no.nav.helse.modell.vergemal.AutomatiskAvisningCommand
+import no.nav.helse.modell.automatisering.AutomatiskAvisningCommand
 import no.nav.helse.oppgave.OppgaveMediator
 import no.nav.helse.rapids_rivers.*
 import org.slf4j.Logger

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
@@ -35,6 +35,7 @@ import no.nav.helse.modell.utbetaling.Utbetalingtype.Companion.values
 import no.nav.helse.modell.vedtak.snapshot.SpeilSnapshotRestClient
 import no.nav.helse.modell.vedtaksperiode.Inntektskilde
 import no.nav.helse.modell.vedtaksperiode.Periodetype
+import no.nav.helse.modell.vergemal.AutomatiskAvisningCommand
 import no.nav.helse.oppgave.OppgaveMediator
 import no.nav.helse.rapids_rivers.*
 import org.slf4j.Logger
@@ -90,10 +91,7 @@ internal class Godkjenningsbehov(
         KlargjørPersonCommand(
             fødselsnummer = fødselsnummer,
             aktørId = aktørId,
-            personDao = personDao,
-            godkjenningsbehovJson = json,
-            vedtaksperiodeId = vedtaksperiodeId,
-            godkjenningMediator = godkjenningMediator,
+            personDao = personDao
         ),
         KlargjørArbeidsgiverCommand(
             orgnummere = (aktiveVedtaksperioder.orgnummere() + orgnummereMedAktiveArbeidsforhold).distinct(),
@@ -125,10 +123,6 @@ internal class Godkjenningsbehov(
         ),
         EgenAnsattCommand(
             egenAnsattDao = egenAnsattDao,
-            godkjenningsbehovJson = json,
-            vedtaksperiodeId = vedtaksperiodeId,
-            fødselsnummer = fødselsnummer,
-            godkjenningMediator = godkjenningMediator,
         ),
         DigitalKontaktinformasjonCommand(
             digitalKontaktinformasjonDao = digitalKontaktinformasjonDao,
@@ -156,6 +150,14 @@ internal class Godkjenningsbehov(
             aktiveVedtaksperioder = aktiveVedtaksperioder,
             risikovurderingDao = risikovurderingDao,
             warningDao = warningDao
+        ),
+        AutomatiskAvisningCommand(
+            fødselsnummer = fødselsnummer,
+            vedtaksperiodeId = vedtaksperiodeId,
+            egenAnsattDao = egenAnsattDao,
+            personDao = personDao,
+            godkjenningsbehovJson = json,
+            godkjenningMediator = godkjenningMediator
         ),
         AutomatiseringCommand(
             fødselsnummer = fødselsnummer,

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/automatisering/AutomatiskAvisningCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/automatisering/AutomatiskAvisningCommand.kt
@@ -1,4 +1,4 @@
-package no.nav.helse.modell.vergemal
+package no.nav.helse.modell.automatisering
 
 import no.nav.helse.avvistPåGrunnAvEgenAnsattTeller
 import no.nav.helse.avvistPåGrunnAvUtlandTeller

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/automatisering/AutomatiskAvisningCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/automatisering/AutomatiskAvisningCommand.kt
@@ -43,6 +43,7 @@ internal class AutomatiskAvisningCommand(
                 godkjenningMediator.lagVedtaksperiodeAvvist(vedtaksperiodeId, fødselsnummer, behov).toJson()
             )
             logg.info("Automatisk avvisning for vedtaksperiode:$vedtaksperiodeId pga:$årsaker")
+            sikkerLogg.info("Automatisk avvisning for vedtaksperiode:$vedtaksperiodeId pga:$årsaker")
         }
         return true
     }

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/egenansatt/EgenAnsattCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/egenansatt/EgenAnsattCommand.kt
@@ -1,20 +1,12 @@
 package no.nav.helse.modell.egenansatt
 
-import no.nav.helse.avvistPåGrunnAvEgenAnsattTeller
-import no.nav.helse.mediator.GodkjenningMediator
 import no.nav.helse.mediator.meldinger.EgenAnsattløsning
-import no.nav.helse.modell.UtbetalingsgodkjenningMessage
 import no.nav.helse.modell.kommando.Command
 import no.nav.helse.modell.kommando.CommandContext
 import org.slf4j.LoggerFactory
-import java.util.*
 
 internal class EgenAnsattCommand(
     private val egenAnsattDao: EgenAnsattDao,
-    private val godkjenningsbehovJson: String,
-    private val vedtaksperiodeId: UUID,
-    private val fødselsnummer: String,
-    private val godkjenningMediator: GodkjenningMediator,
 ) : Command {
 
     private companion object {
@@ -29,17 +21,6 @@ internal class EgenAnsattCommand(
 
     override fun resume(context: CommandContext): Boolean {
         val løsning = context.get<EgenAnsattløsning>() ?: return false
-        val erEgenAnsatt = løsning.evaluer()
-
-        if (erEgenAnsatt) {
-            val behov = UtbetalingsgodkjenningMessage(godkjenningsbehovJson)
-            behov.avvisAutomatisk(listOf("Egen ansatt"))
-            context.publiser(behov.toJson())
-            context.publiser(godkjenningMediator.lagVedtaksperiodeAvvist(vedtaksperiodeId, fødselsnummer, behov).toJson())
-            avvistPåGrunnAvEgenAnsattTeller.inc()
-            logg.info("Automatisk avvisning for vedtaksperiode $vedtaksperiodeId")
-        }
-
         løsning.lagre(egenAnsattDao)
         return true
     }

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/KlargjørPersonCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/KlargjørPersonCommand.kt
@@ -1,19 +1,14 @@
 package no.nav.helse.modell.kommando
 
-import no.nav.helse.mediator.GodkjenningMediator
 import no.nav.helse.modell.person.PersonDao
-import java.util.*
 
 internal class KlargjørPersonCommand(
     fødselsnummer: String,
     aktørId: String,
     personDao: PersonDao,
-    godkjenningsbehovJson: String,
-    vedtaksperiodeId: UUID,
-    godkjenningMediator: GodkjenningMediator,
 ) : MacroCommand() {
     override val commands: List<Command> = listOf(
-        OpprettPersonCommand(fødselsnummer, aktørId, personDao, godkjenningsbehovJson, vedtaksperiodeId, godkjenningMediator),
-        OppdaterPersonCommand(fødselsnummer, personDao, godkjenningsbehovJson, vedtaksperiodeId, godkjenningMediator)
+        OpprettPersonCommand(fødselsnummer, aktørId, personDao),
+        OppdaterPersonCommand(fødselsnummer, personDao)
     )
 }

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/vergemal/AutomatiskAvisningCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/vergemal/AutomatiskAvisningCommand.kt
@@ -1,0 +1,49 @@
+package no.nav.helse.modell.vergemal
+
+import no.nav.helse.avvistPåGrunnAvEgenAnsattTeller
+import no.nav.helse.avvistPåGrunnAvUtlandTeller
+import no.nav.helse.mediator.GodkjenningMediator
+import no.nav.helse.mediator.meldinger.HentEnhetløsning
+import no.nav.helse.modell.UtbetalingsgodkjenningMessage
+import no.nav.helse.modell.egenansatt.EgenAnsattDao
+import no.nav.helse.modell.kommando.Command
+import no.nav.helse.modell.kommando.CommandContext
+import no.nav.helse.modell.person.PersonDao
+import org.slf4j.LoggerFactory
+import java.util.*
+
+internal class AutomatiskAvisningCommand(
+    val fødselsnummer: String,
+    val vedtaksperiodeId: UUID,
+    val egenAnsattDao: EgenAnsattDao,
+    val personDao: PersonDao,
+    val godkjenningsbehovJson: String,
+    val godkjenningMediator: GodkjenningMediator,
+) : Command {
+    private companion object {
+        val logg = LoggerFactory.getLogger(this::class.java)
+        val sikkerLogg = LoggerFactory.getLogger("tjenestekall")
+    }
+
+    override fun execute(context: CommandContext): Boolean {
+        val erEgenAnsatt = egenAnsattDao.erEgenAnsatt(fødselsnummer) ?: false
+        val tilhørerEnhetUtland = HentEnhetløsning.erEnhetUtland(personDao.finnEnhetId(fødselsnummer))
+
+        if (erEgenAnsatt || tilhørerEnhetUtland) {
+            val årsaker = mutableListOf<String>()
+            if (erEgenAnsatt) årsaker.add("Egen ansatt")
+                .also { avvistPåGrunnAvEgenAnsattTeller.inc() }
+            if (tilhørerEnhetUtland) årsaker.add("Utland")
+                .also { avvistPåGrunnAvUtlandTeller.inc() }
+
+            val behov = UtbetalingsgodkjenningMessage(godkjenningsbehovJson)
+            behov.avvisAutomatisk(årsaker.toList())
+            context.publiser(behov.toJson())
+            context.publiser(
+                godkjenningMediator.lagVedtaksperiodeAvvist(vedtaksperiodeId, fødselsnummer, behov).toJson()
+            )
+            logg.info("Automatisk avvisning for vedtaksperiode:$vedtaksperiodeId pga:$årsaker")
+        }
+        return true
+    }
+}

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/OppdaterPersonCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/OppdaterPersonCommandTest.kt
@@ -30,8 +30,8 @@ internal class OppdaterPersonCommandTest {
     }
 
     private val dao = mockk<PersonDao>(relaxed = true)
-    private val godkjenningMediator = mockk<GodkjenningMediator>(relaxed = true)
-    private val command = OppdaterPersonCommand(FNR, dao, """{"@event_name": "behov"}""", UUID.randomUUID(), godkjenningMediator)
+
+    private val command = OppdaterPersonCommand(FNR, dao)
     private lateinit var context: CommandContext
 
     @BeforeEach

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/OpprettPersonCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/OpprettPersonCommandTest.kt
@@ -34,8 +34,7 @@ internal class OpprettPersonCommandTest {
     }
 
     private val dao = mockk<PersonDao>(relaxed = true)
-    private val godkjenningMediator = mockk<GodkjenningMediator>(relaxed = true)
-    private val command = OpprettPersonCommand(FNR, AKTØR, dao, """{"@event_name": "behov"}""", UUID.randomUUID(), godkjenningMediator)
+    private val command = OpprettPersonCommand(FNR, AKTØR, dao)
     private lateinit var context: CommandContext
 
     @BeforeEach


### PR DESCRIPTION
…ando

I dag er det to (snart 3) årsaker til at vi automatisk avviser godkjenningsbehovet:
 - Bruker er egen ansatt
 - Bruker tilhører utenlandsenheten
 - (Bruker er under vergemål)

Hver av disse sjekkene har i dag håndtert dette i isolasjon, som fører til uoversiktlig flyt og potensielt duplikate avslag. Jeg har trukket ut selve avslagsbiten og delegert det til en separat kommando.

De testene jeg har fjerna dekkes allerede gjennom GodkjenningE2E