### PR TITLE
Strammer opp bruken av kotliquery.single

### DIFF
--- a/spesialist-api/src/main/kotlin/no/nav/helse/oppgave/OppgaveDao.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/oppgave/OppgaveDao.kt
@@ -191,7 +191,7 @@ class OppgaveDao(private val dataSource: DataSource) : HelseDao(dataSource) {
         })
 
     fun finnHendelseId(oppgaveId: Long) = requireNotNull(
-        """SELECT hendelse_id FROM command_context WHERE context_id = (SELECT command_context_id FROM oppgave WHERE id = :oppgaveId)"""
+        """SELECT DISTINCT hendelse_id FROM command_context WHERE context_id = (SELECT command_context_id FROM oppgave WHERE id = :oppgaveId)"""
             .single(mapOf("oppgaveId" to oppgaveId)) { row -> UUID.fromString(row.string("hendelse_id")) })
 
     fun harGyldigOppgave(utbetalingId: UUID) = requireNotNull(

--- a/spesialist-api/src/main/kotlin/no/nav/helse/reservasjon/ReservasjonDao.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/reservasjon/ReservasjonDao.kt
@@ -1,26 +1,46 @@
 package no.nav.helse.reservasjon
 
-import no.nav.helse.HelseDao
-import java.util.*
+import java.util.UUID
 import javax.sql.DataSource
+import no.nav.helse.HelseDao
+import org.intellij.lang.annotations.Language
 
-class ReservasjonDao(dataSource: DataSource): HelseDao(dataSource) {
-    fun reserverPerson(saksbehandlerOid: UUID, fødselsnummer: String) =
-        """ INSERT INTO reserver_person(saksbehandler_ref, person_ref)
-            SELECT :saksbehandler_ref, person.id
-            FROM person
-            WHERE person.fodselsnummer = :fodselsnummer;"""
-            .update(mapOf("saksbehandler_ref" to saksbehandlerOid, "fodselsnummer" to fødselsnummer.toLong()))
+class ReservasjonDao(dataSource: DataSource) : HelseDao(dataSource) {
+    fun reserverPerson(saksbehandlerOid: UUID, fødselsnummer: String) {
+        @Language("PostgreSQL")
+        val insertQuery = """
+                INSERT INTO reserver_person(saksbehandler_ref, person_ref)
+                SELECT :saksbehandler_ref, person.id
+                FROM person
+                WHERE person.fodselsnummer = :fodselsnummer
+            """
+
+        @Language("PostgreSQL")
+        val updateQuery = """
+                UPDATE reserver_person
+                SET gyldig_til=now()
+                WHERE saksbehandler_ref = :saksbehandler_ref and person_ref = (
+                    SELECT id FROM person WHERE person.fodselsnummer = :fodselsnummer
+                )
+            """
+        (if (hentReservasjonFor(fødselsnummer) == null) insertQuery else updateQuery).update(
+            mapOf("saksbehandler_ref" to saksbehandlerOid, "fodselsnummer" to fødselsnummer.toLong())
+        )
+    }
 
     fun hentReservasjonFor(fødselsnummer: String) =
         """ SELECT r.* FROM reserver_person r
                 JOIN person p ON p.id = r.person_ref
             WHERE p.fodselsnummer = :fnr AND r.gyldig_til > now(); """
-            .single(mapOf("fnr" to fødselsnummer.toLong())) { UUID.fromString(it.string("saksbehandler_ref")) to it.localDateTime("gyldig_til")}
+            .single(mapOf("fnr" to fødselsnummer.toLong())) {
+                UUID.fromString(it.string("saksbehandler_ref")) to it.localDateTime("gyldig_til")
+            }
 
     fun hentReservasjonFor(personReferanse: Long): UUID? =
         """SELECT * FROM reserver_person WHERE person_ref=:person_ref ORDER BY gyldig_til DESC;"""
-            .single(mapOf("person_ref" to personReferanse)) { row -> UUID.fromString(row.string("saksbehandler_ref"))}
+            .single(mapOf("person_ref" to personReferanse)) { row ->
+                UUID.fromString(row.string("saksbehandler_ref"))
+            }
 
     fun slettReservasjon(saksbehandlerOid: UUID, personReferanse: Long) =
         """DELETE FROM reserver_person WHERE person_ref=:person_ref AND saksbehandler_ref=:saksbehandler_ref;"""

--- a/spesialist-felles/src/main/kotlin/no/nav/helse/HelseDao.kt
+++ b/spesialist-felles/src/main/kotlin/no/nav/helse/HelseDao.kt
@@ -1,11 +1,11 @@
 package no.nav.helse
 
+import javax.sql.DataSource
 import kotliquery.Query
 import kotliquery.Row
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import org.intellij.lang.annotations.Language
-import javax.sql.DataSource
 
 abstract class HelseDao(private val dataSource: DataSource) {
 
@@ -17,7 +17,7 @@ abstract class HelseDao(private val dataSource: DataSource) {
         session.run(queryOf(this, argMap).map { mapping(it) }.asList)
     }
 
-    fun <T> String.single(argMap: Map<String, Any> = emptyMap(), mapping: (Row) -> T?) = sessionOf(dataSource).use { session ->
+    fun <T> String.single(argMap: Map<String, Any> = emptyMap(), mapping: (Row) -> T?) = sessionOf(dataSource, strict = true).use { session ->
         session.run(queryOf(this, argMap).map { mapping(it) }.asSingle)
     }
 

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/e2e/GodkjenningE2ETest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/e2e/GodkjenningE2ETest.kt
@@ -832,7 +832,6 @@ internal class GodkjenningE2ETest : AbstractE2ETest() {
             godkjenningsmeldingId = godkjenningsmeldingId2,
             vedtaksperiodeId = VEDTAKSPERIODE_ID2,
         )
-        sendSaksbehandlerløsning(OPPGAVEID, SAKSBEHANDLERIDENT, SAKSBEHANDLEREPOST, SAKSBEHANDLEROID, true)
 
         val tildeling = tildelingDao.tildelingForOppgave(OPPGAVEID)
         assertEquals(SAKSBEHANDLEREPOST, tildeling?.epost)

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/tildeling/TildelingDaoTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/tildeling/TildelingDaoTest.kt
@@ -1,12 +1,12 @@
 package no.nav.helse.modell.tildeling
 
 import DatabaseIntegrationTest
+import java.time.LocalDateTime
+import java.util.UUID
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import no.nav.helse.oppgave.Oppgavestatus
 import org.junit.jupiter.api.Test
-import java.time.LocalDateTime
-import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -92,23 +92,6 @@ internal class TildelingDaoTest : DatabaseIntegrationTest() {
         tildelTilSaksbehandler()
         val saksbehandlerepost = tildelingDao.tildelingForPerson(FNR)
         assertNull(saksbehandlerepost)
-    }
-
-    @Test
-    fun `henter den siste saksbehandlereposten for tildeling med fødselsnummer`() {
-        val nySaksbehandlerepost = "ny.saksbehandler@nav.no"
-        nyPerson()
-        tildelTilSaksbehandler()
-        opprettVedtaksperiode(vedtaksperiodeId = UUID.randomUUID())
-        opprettOppgave(vedtaksperiodeId = VEDTAKSPERIODE)
-        tildelTilSaksbehandler(
-            oppgaveId = oppgaveId,
-            oid = UUID.randomUUID(),
-            navn = "Ny Saksbehandler",
-            epost = nySaksbehandlerepost
-        )
-        val tildeling = tildelingDao.tildelingForPerson(FNR)
-        assertEquals(nySaksbehandlerepost, tildeling?.epost)
     }
 
     @Test


### PR DESCRIPTION
Ved å sette strict=true vil det bli kastet exception hvis en spørring
skulle returnere mer enn én rad. Bedre å feile hardt enn å risikere
udefinert oppførsel.

Om endringene:
* OppgaveDao.finnHendelseId har alltid funnet en haug med rader - som
  jo heldigvis har hatt lik hendelseId, da
* reserverPerson støtter ikke ON CONFLICT ... fordi det ikke er noen
  index/contraints i tabellen. Jeg tror det holder lenge å løse dette
  i kode.
* I GodkjenningE2ETest ble det sendt inn en overflødig saksbehandler-
  løsning, overflødig fordi det er når _oppgaven_ opprettes vi gjør
  tildelig ut fra reservasjon
* Testen i TildelingDaoTest var litt tøyeste, den hadde som scenario at
  en person/oppgave ble tildelt til en ny saksbehandler, det er det
  ikke støtte for i løsningen