### PR TITLE
Ny tabell hvor vi lagrer vedtaksperiodeId for overstyrte vedtaksperioder

### DIFF
--- a/spesialist-api/src/main/kotlin/no/nav/helse/overstyring/OverstyrtVedtaksperiodeDao.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/overstyring/OverstyrtVedtaksperiodeDao.kt
@@ -1,0 +1,20 @@
+package no.nav.helse.overstyring
+
+import java.util.*
+import javax.sql.DataSource
+import kotliquery.sessionOf
+import no.nav.helse.HelseDao
+
+class OverstyrtVedtaksperiodeDao(private val dataSource: DataSource) : HelseDao(dataSource)  {
+
+    fun erVedtaksperiodeOverstyrt(vedtaksperiodeId: UUID) = sessionOf(dataSource).use {
+        """ SELECT EXISTS ( SELECT 1 FROM overstyrt_vedtaksperiode WHERE vedtaksperiode_id = :vedtaksperiode_id ) 
+        """.single(mapOf("vedtaksperiode_id" to vedtaksperiodeId)) { it.boolean(1) } ?: false
+    }
+
+    fun lagreOverstyrtVedtaksperiode(vedtaksperiodeId: UUID) = sessionOf(dataSource).use {
+        """ INSERT INTO overstyrt_vedtaksperiode (vedtaksperiode_id)
+            VALUES (:vedtaksperiode_id)
+        """.update(mapOf("vedtaksperiode_id" to vedtaksperiodeId))
+    }
+}

--- a/spesialist-api/src/test/kotlin/no/nav/helse/DatabaseIntegrationTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/DatabaseIntegrationTest.kt
@@ -7,6 +7,7 @@ import kotliquery.sessionOf
 import no.nav.helse.arbeidsgiver.ArbeidsgiverApiDao
 import no.nav.helse.db.AbstractDatabaseTest
 import no.nav.helse.notat.NotatDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.person.Adressebeskyttelse
 import no.nav.helse.person.PersonApiDao
 import no.nav.helse.risikovurdering.RisikovurderingApiDao
@@ -32,6 +33,7 @@ internal abstract class DatabaseIntegrationTest : AbstractDatabaseTest() {
     protected val saksbehandlerDao = SaksbehandlerDao(dataSource)
     protected val notatDao = NotatDao(dataSource)
     protected val personApiDao = PersonApiDao(dataSource)
+    protected val overstyrtVedtaksperiodeDao = OverstyrtVedtaksperiodeDao(dataSource)
 
     protected fun nyVedtaksperiode() = sessionOf(dataSource, returnGeneratedKey = true).use { session ->
         val (id, fom, tom) = PERIODE

--- a/spesialist-api/src/test/kotlin/no/nav/helse/overstyring/OverstyrtVedtaksperiodeDaoTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/overstyring/OverstyrtVedtaksperiodeDaoTest.kt
@@ -1,0 +1,26 @@
+package no.nav.helse.overstyring
+
+
+import java.util.UUID
+import no.nav.helse.DatabaseIntegrationTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+internal class OverstyrtVedtaksperiodeDaoTest : DatabaseIntegrationTest() {
+
+    @Test
+    fun `Kan lagre og hente overstyrt vedtaksperiode`() {
+        val vedtaksperiodeId = UUID.randomUUID()
+        overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(vedtaksperiodeId)
+        val erVedtaksperiodeOverstyrt = overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(vedtaksperiodeId)
+        assertTrue(erVedtaksperiodeOverstyrt)
+    }
+
+    @Test
+    fun `Henter ut overstyrt vedtaksperiode`() {
+        val erVedtaksperiodeOverstyrt = overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(UUID.randomUUID())
+        assertFalse(erVedtaksperiodeOverstyrt)
+    }
+}

--- a/spesialist-felles/src/main/resources/db/migration/V208__overstyrt_vedtaksperiode.sql
+++ b/spesialist-felles/src/main/resources/db/migration/V208__overstyrt_vedtaksperiode.sql
@@ -1,0 +1,7 @@
+CREATE TABLE overstyrt_vedtaksperiode
+(
+    id SERIAL PRIMARY KEY,
+    vedtaksperiode_id UUID NOT NULL
+);
+
+CREATE INDEX ON overstyrt_vedtaksperiode (vedtaksperiode_id);

--- a/spesialist-opprydding-dev/src/test/kotlin/no/nav/helse/opprydding/AbstractDatabaseTest.kt
+++ b/spesialist-opprydding-dev/src/test/kotlin/no/nav/helse/opprydding/AbstractDatabaseTest.kt
@@ -110,7 +110,8 @@ internal abstract class AbstractDatabaseTest {
                 "arbeidsgiver",
                 "arbeidsgiver_bransjer",
                 "arbeidsgiver_navn",
-                "periodehistorikk"
+                "periodehistorikk",
+                "overstyrt_vedtaksperiode"
             )
         )
         tabeller.forEach {

--- a/spesialist-opprydding-dev/src/test/kotlin/no/nav/helse/opprydding/PersonRepositoryTest.kt
+++ b/spesialist-opprydding-dev/src/test/kotlin/no/nav/helse/opprydding/PersonRepositoryTest.kt
@@ -17,6 +17,6 @@ internal class PersonRepositoryTest: AbstractDatabaseTest() {
 
     @Test
     fun `antall tabeller - du må antakelig rette opp i sletting i dev dersom du har lagt til eller fjernet tabeller`() {
-        assertEquals(46, finnTabeller().size)
+        assertEquals(47, finnTabeller().size)
     }
 }

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/ApplicationBuilder.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/ApplicationBuilder.kt
@@ -82,6 +82,7 @@ import no.nav.helse.notat.NotatMediator
 import no.nav.helse.oppgave.OppgaveDao
 import no.nav.helse.oppgave.OppgaveMediator
 import no.nav.helse.overstyring.OverstyringApiDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.periodehistorikk.PeriodehistorikkDao
 import no.nav.helse.person.PersonApiDao
 import no.nav.helse.rapids_rivers.RapidApplication
@@ -184,6 +185,7 @@ internal class ApplicationBuilder(env: Map<String, String>) : RapidsConnection.S
     private val snapshotDao = SnapshotDao(dataSource)
     private val vergemålDao = VergemålDao(dataSource)
     private val notatMediator = NotatMediator(notatDao)
+    private val overstyrtVedtaksperiodeDao = OverstyrtVedtaksperiodeDao(dataSource)
 
     private val oppgaveMediator = OppgaveMediator(
         oppgaveDao,
@@ -211,6 +213,7 @@ internal class ApplicationBuilder(env: Map<String, String>) : RapidsConnection.S
         warningDao = warningDao,
         commandContextDao = commandContextDao,
         oppgaveDao = oppgaveDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         reservasjonDao = reservasjonDao,
         tildelingDao = tildelingDao,
         saksbehandlerDao = saksbehandlerDao,

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/Hendelsefabrikk.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/Hendelsefabrikk.kt
@@ -47,6 +47,7 @@ import no.nav.helse.modell.vergemal.VergemålDao
 import no.nav.helse.oppgave.OppgaveDao
 import no.nav.helse.oppgave.OppgaveMediator
 import no.nav.helse.overstyring.OverstyringDagDto
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.rapids_rivers.asLocalDate
 import no.nav.helse.rapids_rivers.asLocalDateTime
 import no.nav.helse.rapids_rivers.isMissingOrNull
@@ -62,6 +63,7 @@ internal class Hendelsefabrikk(
     private val vedtakDao: VedtakDao,
     private val warningDao: WarningDao,
     private val oppgaveDao: OppgaveDao,
+    private val overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
     private val commandContextDao: CommandContextDao,
     private val reservasjonDao: ReservasjonDao,
     private val tildelingDao: TildelingDao,
@@ -146,7 +148,8 @@ internal class Hendelsefabrikk(
             aktiveVedtaksperioder = aktiveVedtaksperioder,
             orgnummereMedRelevanteArbeidsforhold = orgnummereMedRelevanteArbeidsforhold,
             utbetalingDao = utbetalingDao,
-            oppgaveDao = oppgaveDao
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao
         )
     }
 
@@ -254,7 +257,9 @@ internal class Hendelsefabrikk(
         json = json,
         reservasjonDao = reservasjonDao,
         saksbehandlerDao = saksbehandlerDao,
-        overstyringDao = overstyringDao
+        overstyringDao = overstyringDao,
+        oppgaveDao = oppgaveDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
     )
 
     override fun overstyringTidslinje(json: String): OverstyringTidslinje {
@@ -304,6 +309,8 @@ internal class Hendelsefabrikk(
         saksbehandlerDao = saksbehandlerDao,
         overstyringDao = overstyringDao,
         opprettet = opprettet,
+        oppgaveDao = oppgaveDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         json = json
     )
 
@@ -333,6 +340,8 @@ internal class Hendelsefabrikk(
         reservasjonDao = reservasjonDao,
         saksbehandlerDao = saksbehandlerDao,
         overstyringDao = overstyringDao,
+        oppgaveDao = oppgaveDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         json = json
     )
 

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/Godkjenningsbehov.kt
@@ -50,6 +50,7 @@ import no.nav.helse.modell.vergemal.VergemålCommand
 import no.nav.helse.modell.vergemal.VergemålDao
 import no.nav.helse.oppgave.OppgaveDao
 import no.nav.helse.oppgave.OppgaveMediator
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.MessageProblems
@@ -91,7 +92,8 @@ internal class Godkjenningsbehov(
     automatisering: Automatisering,
     godkjenningMediator: GodkjenningMediator,
     utbetalingDao: UtbetalingDao,
-    oppgaveDao: OppgaveDao
+    oppgaveDao: OppgaveDao,
+    overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao
 ) : Hendelse, MacroCommand() {
     private val utbetalingsfilter: () -> Utbetalingsfilter = {
         val utbetaling = snapshotDao.finnUtbetaling(
@@ -224,7 +226,8 @@ internal class Godkjenningsbehov(
         TrengerTotrinnsvurderingCommand(
             vedtaksperiodeId = vedtaksperiodeId,
             warningDao = warningDao,
-            oppgaveDao = oppgaveDao
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao= overstyrtVedtaksperiodeDao
         )
     )
 

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringArbeidsforhold.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringArbeidsforhold.kt
@@ -23,6 +23,9 @@ import no.nav.helse.reservasjon.ReservasjonDao
 import no.nav.helse.saksbehandler.SaksbehandlerDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import no.nav.helse.modell.kommando.PersisterTotrinnsvurderingArbeidsforholdCommand
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 
 internal class OverstyringArbeidsforhold(
     override val id: UUID,
@@ -38,7 +41,9 @@ internal class OverstyringArbeidsforhold(
     private val json: String,
     reservasjonDao: ReservasjonDao,
     saksbehandlerDao: SaksbehandlerDao,
-    overstyringDao: OverstyringDao
+    overstyringDao: OverstyringDao,
+    oppgaveDao: OppgaveDao,
+    overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
 ) : Hendelse, MacroCommand() {
     override val commands: List<Command> = listOf(
         OpprettSaksbehandlerCommand(
@@ -57,6 +62,12 @@ internal class OverstyringArbeidsforhold(
             skjæringstidspunkt = skjæringstidspunkt,
             overstyringDao = overstyringDao,
             opprettet = opprettet
+        ),
+        PersisterTotrinnsvurderingArbeidsforholdCommand(
+            fødselsnummer = fødselsnummer,
+            skjæringstidspunkt = skjæringstidspunkt,
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         ),
         InvaliderSaksbehandlerOppgaveCommand(fødselsnummer, organisasjonsnummer, saksbehandlerDao)
     )

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringInntekt.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringInntekt.kt
@@ -22,6 +22,9 @@ import no.nav.helse.reservasjon.ReservasjonDao
 import no.nav.helse.saksbehandler.SaksbehandlerDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import no.nav.helse.modell.kommando.PersisterTotrinnsvurderingInntektCommand
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 
 /**
  * Tar vare på overstyring av inntekt fra saksbehandler og sletter den opprinnelige oppgaven i påvente av nytt
@@ -45,7 +48,9 @@ internal class OverstyringInntekt(
     private val json: String,
     reservasjonDao: ReservasjonDao,
     saksbehandlerDao: SaksbehandlerDao,
-    overstyringDao: OverstyringDao
+    overstyringDao: OverstyringDao,
+    oppgaveDao: OppgaveDao,
+    overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
 ) : Hendelse, MacroCommand() {
     override val commands: List<Command> = listOf(
         OpprettSaksbehandlerCommand(
@@ -67,6 +72,13 @@ internal class OverstyringInntekt(
             skjæringstidspunkt = skjæringstidspunkt,
             opprettet = opprettet,
             overstyringDao = overstyringDao
+        ),
+        PersisterTotrinnsvurderingInntektCommand(
+            fødselsnummer = fødselsnummer,
+            organisasjonsnummer = orgnummer,
+            skjæringstidspunkt = skjæringstidspunkt,
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         ),
         InvaliderSaksbehandlerOppgaveCommand(fødselsnummer, orgnummer, saksbehandlerDao)
     )

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringTidslinje.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringTidslinje.kt
@@ -22,6 +22,9 @@ import no.nav.helse.reservasjon.ReservasjonDao
 import no.nav.helse.saksbehandler.SaksbehandlerDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import no.nav.helse.modell.kommando.PersisterTotrinnsvurderingTidslinjeCommand
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 
 /**
  * Tar vare på overstyring fra saksbehandler og sletter den opprinnelige oppgaven i påvente av nytt
@@ -43,7 +46,9 @@ internal class OverstyringTidslinje(
     private val json: String,
     reservasjonDao: ReservasjonDao,
     saksbehandlerDao: SaksbehandlerDao,
-    overstyringDao: OverstyringDao
+    overstyringDao: OverstyringDao,
+    oppgaveDao: OppgaveDao,
+    overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
 ) : Hendelse, MacroCommand() {
     override val commands: List<Command> = listOf(
         OpprettSaksbehandlerCommand(
@@ -63,6 +68,13 @@ internal class OverstyringTidslinje(
             overstyrteDager = overstyrteDager,
             overstyringDao = overstyringDao,
             opprettet = opprettet,
+        ),
+        PersisterTotrinnsvurderingTidslinjeCommand(
+            fødselsnummer = fødselsnummer,
+            organisasjonsnummer = orgnummer,
+            overstyrteDager = overstyrteDager,
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         ),
         InvaliderSaksbehandlerOppgaveCommand(fødselsnummer, orgnummer, saksbehandlerDao)
     )

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingArbeidsforholdCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingArbeidsforholdCommand.kt
@@ -1,0 +1,28 @@
+package no.nav.helse.modell.kommando
+
+import java.time.LocalDate
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.slf4j.LoggerFactory
+
+internal class PersisterTotrinnsvurderingArbeidsforholdCommand(
+    private val fødselsnummer: String,
+    private val skjæringstidspunkt: LocalDate,
+    private val oppgaveDao: OppgaveDao,
+    private val overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
+) : Command {
+    private val sikkerLogg = LoggerFactory.getLogger("tjenestekall")
+
+    override fun execute(context: CommandContext): Boolean {
+        val vedtaksperiodeId = oppgaveDao.finnAktivVedtaksperiodeIdForSkjæringstidspunkt(fødselsnummer, skjæringstidspunkt)
+
+        if(vedtaksperiodeId != null) {
+            sikkerLogg.info("Fant vedtaksperiodeId $vedtaksperiodeId for fnr $fødselsnummer og skjæringstidspunkt $skjæringstidspunkt")
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(vedtaksperiodeId)
+        } else {
+            sikkerLogg.info("Fant ikke vedtaksperiodeId for fnr $fødselsnummer og skjæringstidspunkt $skjæringstidspunkt")
+        }
+
+        return true
+    }
+}

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingInntektCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingInntektCommand.kt
@@ -1,0 +1,29 @@
+package no.nav.helse.modell.kommando
+
+import java.time.LocalDate
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.slf4j.LoggerFactory
+
+internal class PersisterTotrinnsvurderingInntektCommand(
+    private val fødselsnummer: String,
+    private val organisasjonsnummer: String,
+    private val skjæringstidspunkt: LocalDate,
+    private val oppgaveDao: OppgaveDao,
+    private val overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
+) : Command {
+    private val sikkerLogg = LoggerFactory.getLogger("tjenestekall")
+
+    override fun execute(context: CommandContext): Boolean {
+        val vedtaksperiodeId = oppgaveDao.finnNyesteUtbetalteEllerAktiveVedtaksperiodeIdForSkjæringstidspunkt(fødselsnummer, organisasjonsnummer, skjæringstidspunkt)
+
+        if(vedtaksperiodeId != null) {
+            sikkerLogg.info("Fant vedtaksperiodeId $vedtaksperiodeId for fnr $fødselsnummer, orgnr $organisasjonsnummer og skjæringstidspunkt $skjæringstidspunkt")
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(vedtaksperiodeId)
+        } else {
+            sikkerLogg.info("Fant ikke vedtaksperiodeId for fnr $fødselsnummer, orgnr $organisasjonsnummer og skjæringstidspunkt $skjæringstidspunkt")
+        }
+
+        return true
+    }
+}

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingTidslinjeCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingTidslinjeCommand.kt
@@ -1,0 +1,35 @@
+package no.nav.helse.modell.kommando
+
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyringDagDto
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.slf4j.LoggerFactory
+
+internal class PersisterTotrinnsvurderingTidslinjeCommand(
+    private val fødselsnummer: String,
+    private val organisasjonsnummer: String,
+    private val overstyrteDager: List<OverstyringDagDto>,
+    private val oppgaveDao: OppgaveDao,
+    private val overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
+) : Command {
+    private val sikkerLogg = LoggerFactory.getLogger("tjenestekall")
+
+    override fun execute(context: CommandContext): Boolean {
+        if (overstyrteDager.isEmpty()) {
+            sikkerLogg.info("OverstyrteDager er tom for fnr $fødselsnummer og orgnr $organisasjonsnummer i PersisterTotrinnsvurderingTidslinjeCommand")
+            return true
+        }
+        val forsteDag = overstyrteDager.first().dato
+
+        val vedtaksperiodeId = oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(fødselsnummer, organisasjonsnummer, overstyrteDager)
+
+        if(vedtaksperiodeId != null) {
+            sikkerLogg.info("Fant vedtaksperiodeId $vedtaksperiodeId for fnr $fødselsnummer, orgnr $organisasjonsnummer og første overstyrte dag $forsteDag")
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(vedtaksperiodeId)
+        } else {
+            sikkerLogg.info("Fant ikke vedtaksperiodeId for fnr $fødselsnummer, orgnr $organisasjonsnummer og første overstyrte dag $forsteDag ")
+        }
+
+        return true
+    }
+}

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/TrengerTotrinnsvurderingCommand.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/modell/kommando/TrengerTotrinnsvurderingCommand.kt
@@ -3,12 +3,14 @@ package no.nav.helse.modell.kommando
 import java.util.UUID
 import no.nav.helse.modell.WarningDao
 import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import org.slf4j.LoggerFactory
 
 internal class TrengerTotrinnsvurderingCommand(
     private val vedtaksperiodeId: UUID,
     private val warningDao: WarningDao,
-    private val oppgaveDao: OppgaveDao
+    private val oppgaveDao: OppgaveDao,
+    private val overstyrtVedtaksperiodeDao: OverstyrtVedtaksperiodeDao,
 ) : Command {
 
     private companion object {
@@ -16,8 +18,8 @@ internal class TrengerTotrinnsvurderingCommand(
     }
     override fun execute(context: CommandContext): Boolean {
 
-        if (harMedlemskapsVarsel() || harOppgaveMedEndring()) {
-            logg.info("Vedtaksperioden: $vedtaksperiodeId setter trenger totrinnsvurdering")
+        if (harMedlemskapsVarsel() || harOverstyringEllerRevurdering()) {
+            logg.info("Vedtaksperioden: $vedtaksperiodeId trenger totrinnsvurdering")
             oppgaveDao.setTrengerTotrinnsvurdering(vedtaksperiodeId)
         }
 
@@ -26,7 +28,6 @@ internal class TrengerTotrinnsvurderingCommand(
 
     private fun harMedlemskapsVarsel(): Boolean {
         val medlemSkapVarsel = "Vurder lovvalg og medlemskap"
-
         val harMedlemskapsVarsel = warningDao.finnAktiveWarningsMedMelding(vedtaksperiodeId, medlemSkapVarsel).isNotEmpty()
 
         logg.info("Vedtaksperioden: $vedtaksperiodeId harMedlemskapsVarsel: $harMedlemskapsVarsel")
@@ -34,13 +35,12 @@ internal class TrengerTotrinnsvurderingCommand(
         return harMedlemskapsVarsel
     }
 
-    private fun harOppgaveMedEndring(): Boolean {
+    private fun harOverstyringEllerRevurdering(): Boolean {
+        val erVedtaksperiodeOverstyrt = overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(vedtaksperiodeId)
 
-        val harOppgaveMedEndring = oppgaveDao.harOppgaveMedEndring(vedtaksperiodeId)
+        logg.info("Vedtaksperioden: $vedtaksperiodeId har tidligere blitt overstyrt eller revurdert: $erVedtaksperiodeOverstyrt")
 
-        logg.info("Vedtaksperioden: $vedtaksperiodeId harOppgaveMedEndring: $harOppgaveMedEndring")
-
-        return harOppgaveMedEndring
+        return erVedtaksperiodeOverstyrt
     }
 
 }

--- a/spesialist-selve/src/test/kotlin/AbstractE2ETest.kt
+++ b/spesialist-selve/src/test/kotlin/AbstractE2ETest.kt
@@ -78,6 +78,7 @@ import no.nav.helse.oppgave.OppgaveMediator
 import no.nav.helse.oppgave.Oppgavestatus
 import no.nav.helse.overstyring.OverstyringApiDao
 import no.nav.helse.overstyring.OverstyringDagDto
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.periodehistorikk.PeriodehistorikkDao
 import no.nav.helse.person.PersonApiDao
 import no.nav.helse.rapids_rivers.asLocalDateTime
@@ -167,6 +168,7 @@ internal abstract class AbstractE2ETest : AbstractDatabaseTest() {
     protected val reservasjonDao = ReservasjonDao(dataSource)
     protected val notatDao = NotatDao(dataSource)
     protected val vergemålDao = VergemålDao(dataSource)
+    protected val overstyrtVedtaksperiodeDao = OverstyrtVedtaksperiodeDao(dataSource)
 
     protected val snapshotClient = mockk<SnapshotClient>(relaxed = true)
 
@@ -211,6 +213,7 @@ internal abstract class AbstractE2ETest : AbstractDatabaseTest() {
         utbetalingDao = utbetalingDao,
         opptegnelseDao = opptegnelseDao,
         vergemålDao = vergemålDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao
     )
     internal val hendelseMediator = HendelseMediator(
         rapidsConnection = testRapid,

--- a/spesialist-selve/src/test/kotlin/DatabaseIntegrationTest.kt
+++ b/spesialist-selve/src/test/kotlin/DatabaseIntegrationTest.kt
@@ -49,6 +49,7 @@ import no.nav.helse.oppgave.OppgaveDao
 import no.nav.helse.oppgave.Oppgavestatus
 import no.nav.helse.oppgave.Oppgavetype
 import no.nav.helse.overstyring.OverstyringApiDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import no.nav.helse.periodehistorikk.PeriodehistorikkDao
 import no.nav.helse.person.Adressebeskyttelse
 import no.nav.helse.person.Kjønn
@@ -158,6 +159,7 @@ abstract class DatabaseIntegrationTest : AbstractDatabaseTest() {
     internal val feilendeMeldingerDao = FeilendeMeldingerDao(dataSource)
     internal val behandlingsstatistikkDao = BehandlingsstatistikkDao(dataSource)
     internal val vergemålDao = VergemålDao(dataSource)
+    internal val overstyrtVedtaksperiodeDao = OverstyrtVedtaksperiodeDao(dataSource)
 
     internal fun testhendelse(
         hendelseId: UUID = HENDELSE_ID,

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/e2e/TotrinnsvurderingE2ETest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/e2e/TotrinnsvurderingE2ETest.kt
@@ -1,0 +1,56 @@
+package no.nav.helse.e2e
+
+import AbstractE2ETest
+import java.time.LocalDate
+import no.nav.helse.januar
+import no.nav.helse.mediator.api.OverstyrArbeidsforholdDto
+import no.nav.helse.overstyring.Dagtype
+import no.nav.helse.overstyring.OverstyringDagDto
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class TotrinnsvurderingE2ETest : AbstractE2ETest() {
+
+    @Test
+    fun `sak blir trukket til totrinnsvurdering ved overstyring av inntekt`() {
+        settOppBruker()
+        sendOverstyrtInntekt(
+            månedligInntekt = 25000.0,
+            skjæringstidspunkt = 1.januar,
+            forklaring = "vår egen forklaring"
+        )
+        assertTrue(overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(VEDTAKSPERIODE_ID))
+    }
+
+    @Test
+    fun `sak blir trukket til totrinnsvurdering ved overstyring av arbeidsforhold`() {
+        settOppBruker(orgnummereMedRelevanteArbeidsforhold = listOf(ORGNR_GHOST))
+        sendOverstyrtArbeidsforhold(
+            skjæringstidspunkt = 1.januar,
+            overstyrteArbeidsforhold = listOf(
+                OverstyrArbeidsforholdDto.ArbeidsforholdOverstyrt(
+                    orgnummer = ORGNR_GHOST,
+                    deaktivert = true,
+                    begrunnelse = "begrunnelse",
+                    forklaring = "forklaring"
+                )
+            )
+        )
+        assertTrue(overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(VEDTAKSPERIODE_ID))
+    }
+
+    @Test
+    fun `sak blir trukket til totrinnsvurdering ved overstyring av tidslinje`() {
+        settOppBruker()
+        sendOverstyrteDager(
+            listOf(
+                OverstyringDagDto(
+                    dato = LocalDate.of(2018, 1, 20),
+                    type = Dagtype.Feriedag,
+                    grad = null
+                )
+            )
+        )
+        assertTrue(overstyrtVedtaksperiodeDao.erVedtaksperiodeOverstyrt(VEDTAKSPERIODE_ID))
+    }
+}

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/OverstyringTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/OverstyringTest.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.mediator.meldinger
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.time.LocalDate
@@ -15,6 +16,7 @@ import no.nav.helse.saksbehandler.SaksbehandlerDao
 import no.nav.helse.tildeling.TildelingDao
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import no.nav.helse.oppgave.OppgaveDao
 
 internal class OverstyringTest {
     companion object {
@@ -42,13 +44,14 @@ internal class OverstyringTest {
     private val tildelingDao = mockk<TildelingDao>(relaxed = true)
     private val overstyringDao = mockk<OverstyringDao>(relaxed = true)
     private val risikovurderingDao = mockk<RisikovurderingDao>(relaxed = true)
+    private val oppgaveDao = mockk<OppgaveDao>(relaxed = true)
     private val hendelsefabrikk = Hendelsefabrikk(
         hendelseDao = mockk(),
         personDao = mockk(),
         arbeidsgiverDao = mockk(),
         vedtakDao = mockk(),
         warningDao = mockk(),
-        oppgaveDao = mockk(),
+        oppgaveDao = oppgaveDao,
         commandContextDao = mockk(),
         snapshotDao = mockk(),
         reservasjonDao = reservasjonDao,
@@ -66,7 +69,8 @@ internal class OverstyringTest {
         arbeidsforholdDao = mockk(relaxed = true),
         utbetalingDao = mockk(relaxed = true),
         opptegnelseDao = mockk(relaxed = true),
-        vergemålDao = mockk(relaxed = true)
+        vergemålDao = mockk(relaxed = true),
+        overstyrtVedtaksperiodeDao = mockk(relaxed = true)
     )
 
     private val overstyringMessage = hendelsefabrikk.overstyringTidslinje(
@@ -92,6 +96,8 @@ internal class OverstyringTest {
 
     @Test
     fun `Persisterer overstyring`() {
+        every { oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(any(),any(),any()) } returns(null)
+
         overstyringMessage.execute(context)
 
         verify(exactly = 1) { saksbehandlerDao.opprettSaksbehandler(OID, NAVN, EPOST, IDENT) }

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/SaksbehandlerløsningTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/SaksbehandlerløsningTest.kt
@@ -79,7 +79,8 @@ internal class SaksbehandlerløsningTest {
         arbeidsforholdDao = mockk(relaxed = true),
         utbetalingDao = mockk(relaxed = true),
         opptegnelseDao = mockk(relaxed = true),
-        vergemålDao = mockk(relaxed = true)
+        vergemålDao = mockk(relaxed = true),
+        overstyrtVedtaksperiodeDao = mockk(relaxed = true)
     )
 
     private val godkjenningsbehov = UtbetalingsgodkjenningMessage(GODKJENNINGSBEHOV_JSON)

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/VedtaksperiodeForkastetTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/VedtaksperiodeForkastetTest.kt
@@ -71,7 +71,8 @@ internal class VedtaksperiodeForkastetTest {
             arbeidsforholdDao = mockk(relaxed = true),
             utbetalingDao = mockk(relaxed = true),
             opptegnelseDao = mockk(relaxed = true),
-            vergemålDao = mockk(relaxed = true)
+            vergemålDao = mockk(relaxed = true),
+            overstyrtVedtaksperiodeDao = mockk(relaxed = true)
         )
     private val context = CommandContext(CONTEXT)
     private val vedtaksperiodeForkastetMessage = testhendelsefabrikk.vedtaksperiodeForkastet(

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/HendelseDaoTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/HendelseDaoTest.kt
@@ -51,7 +51,8 @@ internal class HendelseDaoTest : DatabaseIntegrationTest() {
             arbeidsforholdDao = arbeidsforholdDao,
             utbetalingDao = utbetalingDao,
             opptegnelseDao = opptegnelseDao,
-            vergemålDao = vergemålDao
+            vergemålDao = vergemålDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao
         )
     }
 

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingArbeidsforholdCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingArbeidsforholdCommandTest.kt
@@ -1,0 +1,63 @@
+package no.nav.helse.modell.kommando
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import no.nav.helse.januar
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PersisterTotrinnsvurderingArbeidsforholdCommandTest {
+    private companion object {
+        private val VEDTAKSPERIODE_ID = UUID.randomUUID()
+        private const val FNR = "12345678911"
+        private val SKJÆRINGSTIDSPUNKT = 1.januar
+    }
+
+    private val oppgaveDao = mockk<OppgaveDao>(relaxed = true)
+    private val overstyrtVedtaksperiodeDao = mockk<OverstyrtVedtaksperiodeDao>(relaxed = true)
+
+    private val context = CommandContext(UUID.randomUUID())
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(oppgaveDao, overstyrtVedtaksperiodeDao)
+    }
+
+    @Test
+    fun `lagrer overstyrt vedtaksperiode hvis vi finner aktiv vedtaksperiode for skjæringstidspunkt`() {
+        every { oppgaveDao.finnAktivVedtaksperiodeIdForSkjæringstidspunkt(FNR, SKJÆRINGSTIDSPUNKT) }.returns(VEDTAKSPERIODE_ID)
+
+        val command = PersisterTotrinnsvurderingArbeidsforholdCommand(
+            FNR,
+            SKJÆRINGSTIDSPUNKT,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao
+        )
+        command.execute(context)
+
+        verify(exactly = 1) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(VEDTAKSPERIODE_ID)
+        }
+    }
+
+    @Test
+    fun `lagrer ikke overstyrt vedtaksperiode hvis vi ikke finner aktiv vedtaksperiode for skjæringstidspunkt`() {
+        every { oppgaveDao.finnAktivVedtaksperiodeIdForSkjæringstidspunkt(any(), any()) }.returns(null)
+
+        val command = PersisterTotrinnsvurderingArbeidsforholdCommand(
+            FNR,
+            SKJÆRINGSTIDSPUNKT,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao)
+        command.execute(context)
+
+        verify(exactly = 0) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(any())
+        }
+    }
+}

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingInntektCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingInntektCommandTest.kt
@@ -1,0 +1,66 @@
+package no.nav.helse.modell.kommando
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import no.nav.helse.januar
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PersisterTotrinnsvurderingInntektCommandTest {
+    private companion object {
+        private val VEDTAKSPERIODE_ID = UUID.randomUUID()
+        private const val FNR = "12345678911"
+        private const val ORGNR = "123456789"
+        private val SKJÆRINGSTIDSPUNKT = 1.januar
+    }
+
+    private val oppgaveDao = mockk<OppgaveDao>(relaxed = true)
+    private val overstyrtVedtaksperiodeDao = mockk<OverstyrtVedtaksperiodeDao>(relaxed = true)
+
+    private val context = CommandContext(UUID.randomUUID())
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(oppgaveDao, overstyrtVedtaksperiodeDao)
+    }
+
+    @Test
+    fun `lagrer overstyrt vedtaksperiode hvis vi finner utbetalt eller aktiv vedtaksperiode for skjæringstidspunkt`() {
+        every { oppgaveDao.finnNyesteUtbetalteEllerAktiveVedtaksperiodeIdForSkjæringstidspunkt(FNR, ORGNR, SKJÆRINGSTIDSPUNKT) }.returns(VEDTAKSPERIODE_ID)
+
+        val command = PersisterTotrinnsvurderingInntektCommand(
+            FNR,
+            ORGNR,
+            SKJÆRINGSTIDSPUNKT,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao
+        )
+        command.execute(context)
+
+        verify(exactly = 1) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(VEDTAKSPERIODE_ID)
+        }
+    }
+
+    @Test
+    fun `lagrer ikke overstyrt vedtaksperiode hvis vi ikke finner utbetalt eller aktiv vedtaksperiode for skjæringstidspunkt`() {
+        every { oppgaveDao.finnNyesteUtbetalteEllerAktiveVedtaksperiodeIdForSkjæringstidspunkt(any(), any(), any()) }.returns(null)
+
+        val command = PersisterTotrinnsvurderingInntektCommand(
+            FNR,
+            ORGNR,
+            SKJÆRINGSTIDSPUNKT,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao)
+        command.execute(context)
+
+        verify(exactly = 0) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(any())
+        }
+    }
+}

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingTidslinjeCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/PersisterTotrinnsvurderingTidslinjeCommandTest.kt
@@ -1,0 +1,94 @@
+package no.nav.helse.modell.kommando
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import no.nav.helse.januar
+import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.Dagtype
+import no.nav.helse.overstyring.OverstyringDagDto
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PersisterTotrinnsvurderingTidslinjeCommandTest {
+    private companion object {
+        private val VEDTAKSPERIODE_ID = UUID.randomUUID()
+        private const val FNR = "12345678911"
+        private const val ORGNR = "123456789"
+        private val OVERSTYRTE_DAGER = listOf(
+            OverstyringDagDto(
+                dato = 1.januar,
+                type = Dagtype.Sykedag,
+                grad = 100
+            )
+        )
+    }
+
+    private val oppgaveDao = mockk<OppgaveDao>(relaxed = true)
+    private val overstyrtVedtaksperiodeDao = mockk<OverstyrtVedtaksperiodeDao>(relaxed = true)
+
+    private val context = CommandContext(UUID.randomUUID())
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(oppgaveDao, overstyrtVedtaksperiodeDao)
+    }
+
+    @Test
+    fun `lagrer overstyrt vedtaksperiode hvis vi finner vedtaksperiode som inneholder første overstyrt dag`() {
+        every { oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(FNR, ORGNR, OVERSTYRTE_DAGER) }.returns(VEDTAKSPERIODE_ID)
+
+        val command = PersisterTotrinnsvurderingTidslinjeCommand(
+            FNR,
+            ORGNR,
+            OVERSTYRTE_DAGER,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao
+        )
+        command.execute(context)
+
+        verify(exactly = 1) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(VEDTAKSPERIODE_ID)
+        }
+    }
+
+    @Test
+    fun `lagrer ikke overstyrt vedtaksperiode hvis vi ikke finner vedtaksperiode som inneholder første overstyrt dag`() {
+        every { oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(any(), any(), any()) }.returns(null)
+
+        val command = PersisterTotrinnsvurderingTidslinjeCommand(
+            FNR,
+            ORGNR,
+            OVERSTYRTE_DAGER,
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao)
+        command.execute(context)
+
+        verify(exactly = 0) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(any())
+        }
+    }
+
+    @Test
+    fun `Hopper ut tidlig hvis overstyrte dager er tom`() {
+        every { oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(any(), any(), any()) }.returns(null)
+
+        val command = PersisterTotrinnsvurderingTidslinjeCommand(
+            FNR,
+            ORGNR,
+            listOf(),
+            oppgaveDao,
+            overstyrtVedtaksperiodeDao)
+        command.execute(context)
+
+        verify(exactly = 0) {
+            oppgaveDao.finnVedtaksperiodeIdForPeriodeMedDager(any(), any(), any())
+        }
+        verify(exactly = 0) {
+            overstyrtVedtaksperiodeDao.lagreOverstyrtVedtaksperiode(any())
+        }
+    }
+}

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/TrengerTotrinnsvurderingCommandTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/kommando/TrengerTotrinnsvurderingCommandTest.kt
@@ -10,6 +10,7 @@ import no.nav.helse.modell.vedtak.Warning
 import no.nav.helse.modell.vedtak.WarningKilde
 
 import no.nav.helse.oppgave.OppgaveDao
+import no.nav.helse.overstyring.OverstyrtVedtaksperiodeDao
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -23,12 +24,14 @@ internal class TrengerTotrinnsvurderingCommandTest {
 
     private val warningDao = mockk<WarningDao>(relaxed = true)
     private val oppgaveDao = mockk<OppgaveDao>(relaxed = true)
+    private val overstyrtVedtaksperiodeDao = mockk<OverstyrtVedtaksperiodeDao>(relaxed = true)
     private lateinit var context: CommandContext
 
     private val command = TrengerTotrinnsvurderingCommand(
         vedtaksperiodeId = VEDTAKSPERIODE_ID,
         warningDao = warningDao,
-        oppgaveDao = oppgaveDao
+        oppgaveDao = oppgaveDao,
+        overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao
     )
 
     @BeforeEach

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/modell/overstyring/OverstyringDaoTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/modell/overstyring/OverstyringDaoTest.kt
@@ -112,7 +112,9 @@ internal class OverstyringDaoTest : DatabaseIntegrationTest() {
             json = "{}",
             reservasjonDao = reservasjonDao,
             saksbehandlerDao = saksbehandlerDao,
-            overstyringDao = overstyringDao
+            overstyringDao = overstyringDao,
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao
         ))
         overstyringDao.persisterOverstyringArbeidsforhold(
             ID,
@@ -156,7 +158,9 @@ internal class OverstyringDaoTest : DatabaseIntegrationTest() {
             json = "{}",
             reservasjonDao = reservasjonDao,
             saksbehandlerDao = saksbehandlerDao,
-            overstyringDao = overstyringDao
+            overstyringDao = overstyringDao,
+            oppgaveDao = oppgaveDao,
+            overstyrtVedtaksperiodeDao = overstyrtVedtaksperiodeDao,
         )
     )
 }


### PR DESCRIPTION
* Lar oss enkelt hente opp hvilke vedtaksperioder som er overstyrt/revurdert i TrengerTotrinnsvurderingCommand.

Co-authored-by: Jonas Hasle <jonas.hasle@nav.no>
Co-authored-by: Joakim Taule Kartveit <joakim.taule.kartveit@nav.no>