### PR TITLE
Saksbehandler håndterer annullering, samler oppførsel i mediator

### DIFF
--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/Metrikker.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/Metrikker.kt
@@ -1,12 +1,15 @@
 package no.nav.helse.spesialist.api
 
 import io.prometheus.client.Counter
+import no.nav.helse.spesialist.api.utbetaling.SaksbehandlerHendelse
 
 //private val overstyringsteller = Counter.build("overstyringer", "Teller antall overstyringer")
 //    .labelNames("opplysningstype", "type")
 //    .register()
 
-private val annulleringsteller = Counter.build("annulleringer", "Teller antall annulleringer")
-    .register()
+private val tellere = mutableMapOf<String, Counter>()
 
-internal fun tellAnnullering() = annulleringsteller.inc()
+internal fun tellHendelse(hendelse: SaksbehandlerHendelse) {
+    val tellernavn = hendelse.tellernavn()
+    tellere.getOrPut(tellernavn) { Counter.build(tellernavn, "Teller antall $tellernavn").register() }.inc()
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/Metrikker.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/Metrikker.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.spesialist.api
 
 import io.prometheus.client.Counter
-import no.nav.helse.spesialist.api.utbetaling.SaksbehandlerHendelse
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerHendelse
 
 //private val overstyringsteller = Counter.build("overstyringer", "Teller antall overstyringer")
 //    .labelNames("opplysningstype", "type")

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
@@ -4,43 +4,59 @@ import javax.sql.DataSource
 import net.logstash.logback.argument.StructuredArguments.keyValue
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.spesialist.api.saksbehandler.Saksbehandler
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDao
-import no.nav.helse.spesialist.api.utbetaling.AnnulleringDto
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerObserver
+import no.nav.helse.spesialist.api.utbetaling.SaksbehandlerHendelse
 import org.slf4j.LoggerFactory
 
 class SaksbehandlerMediator(
     dataSource: DataSource,
     private val rapidsConnection: RapidsConnection
-) {
+): SaksbehandlerObserver {
     private val saksbehandlerDao = SaksbehandlerDao(dataSource)
-
-    fun håndter(annulleringDto: AnnulleringDto, saksbehandler: Saksbehandler) {
-        tellAnnullering()
-        saksbehandler.persister(saksbehandlerDao)
-
-        val annulleringMessage = JsonMessage.newMessage("annullering", mutableMapOf(
-            "fødselsnummer" to annulleringDto.fødselsnummer,
-            "organisasjonsnummer" to annulleringDto.organisasjonsnummer,
-            "aktørId" to annulleringDto.aktørId,
-            "saksbehandler" to saksbehandler.json().toMutableMap()
-                .apply { put("ident", annulleringDto.saksbehandlerIdent) },
-            "fagsystemId" to annulleringDto.fagsystemId,
-            "begrunnelser" to annulleringDto.begrunnelser,
-        ).apply {
-            compute("kommentar") { _, _ -> annulleringDto.kommentar }
-        })
-
-        rapidsConnection.publish(annulleringDto.fødselsnummer, annulleringMessage.toJson().also {
-            sikkerlogg.info(
-                "sender annullering for {}, {}\n\t$it",
-                keyValue("fødselsnummer", annulleringDto.fødselsnummer),
-                keyValue("organisasjonsnummer", annulleringDto.organisasjonsnummer)
-            )
-        })
-    }
 
     private companion object {
         private val sikkerlogg = LoggerFactory.getLogger("tjenestekall")
+    }
+
+    fun <T: SaksbehandlerHendelse> håndter(hendelse: T, saksbehandlerDto: SaksbehandlerDto) {
+        val saksbehandlerOid = saksbehandlerDto.oid
+        if (saksbehandlerOid != hendelse.saksbehandlerOid()) throw IllegalStateException()
+        val saksbehandler = saksbehandlerDao.finnSaksbehandlerFor(saksbehandlerOid) ?: saksbehandlerDao.opprettFra(saksbehandlerDto)
+        saksbehandler.register(this)
+        sikkerlogg.info("$saksbehandler behandler nå ${hendelse::class.simpleName}")
+        hendelse.håndter(saksbehandler)
+        sikkerlogg.info("$saksbehandler har ferdigbehandlet ${hendelse::class.simpleName}")
+        tellHendelse(hendelse)
+    }
+
+    override fun annulleringEvent(
+        aktørId: String,
+        fødselsnummer: String,
+        organisasjonsnummer: String,
+        saksbehandler: Map<String, Any>,
+        fagsystemId: String,
+        begrunnelser: List<String>,
+        kommentar: String?
+    ) {
+        val annulleringMessage = JsonMessage.newMessage("annullering", mutableMapOf(
+            "fødselsnummer" to fødselsnummer,
+            "organisasjonsnummer" to organisasjonsnummer,
+            "aktørId" to aktørId,
+            "saksbehandler" to saksbehandler,
+            "fagsystemId" to fagsystemId,
+            "begrunnelser" to begrunnelser,
+        ).apply {
+            compute("kommentar") { _, _ -> kommentar }
+        })
+
+        rapidsConnection.publish(fødselsnummer, annulleringMessage.toJson().also {
+            sikkerlogg.info(
+                "sender annullering for {}, {}\n\t$it",
+                keyValue("fødselsnummer", fødselsnummer),
+                keyValue("organisasjonsnummer", organisasjonsnummer)
+            )
+        })
     }
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
@@ -6,8 +6,8 @@ import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDao
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerHendelse
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerObserver
-import no.nav.helse.spesialist.api.utbetaling.SaksbehandlerHendelse
 import org.slf4j.LoggerFactory
 
 class SaksbehandlerMediator(

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
@@ -4,6 +4,7 @@ import javax.sql.DataSource
 import net.logstash.logback.argument.StructuredArguments.keyValue
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.spesialist.api.overstyring.OverstyrTidslinje.Overstyringdag
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDao
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto
 import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerHendelse
@@ -50,8 +51,31 @@ class SaksbehandlerMediator(
         ).apply {
             compute("kommentar") { _, _ -> kommentar }
         }
-
         nyMelding(aktørId, fødselsnummer, organisasjonsnummer, "annullering", verdier)
+    }
+
+    override fun overstyrTidslinjeEvent(
+        aktørId: String,
+        fødselsnummer: String,
+        organisasjonsnummer: String,
+        saksbehandler: Map<String, Any>,
+        begrunnelse: String,
+        dager: List<Overstyringdag>
+    ) {
+        nyMelding(
+            aktørId,
+            fødselsnummer,
+            organisasjonsnummer,
+            "saksbehandler_overstyrer_tidslinje",
+            mapOf(
+                "fødselsnummer" to fødselsnummer,
+                "aktørId" to aktørId,
+                "organisasjonsnummer" to organisasjonsnummer,
+                "dager" to dager.map(Overstyringdag::toJson),
+                "begrunnelse" to begrunnelse,
+                "saksbehandler" to saksbehandler,
+            )
+        )
     }
 
     private fun nyMelding(aktørId: String, fødselsnummer: String, organisasjonsnummer: String, eventName: String, verdier: Map<String, Any>) {

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/SaksbehandlerMediator.kt
@@ -40,7 +40,7 @@ class SaksbehandlerMediator(
         begrunnelser: List<String>,
         kommentar: String?
     ) {
-        val annulleringMessage = JsonMessage.newMessage("annullering", mutableMapOf(
+        val verdier = mutableMapOf(
             "fødselsnummer" to fødselsnummer,
             "organisasjonsnummer" to organisasjonsnummer,
             "aktørId" to aktørId,
@@ -49,14 +49,20 @@ class SaksbehandlerMediator(
             "begrunnelser" to begrunnelser,
         ).apply {
             compute("kommentar") { _, _ -> kommentar }
-        })
+        }
 
-        rapidsConnection.publish(fødselsnummer, annulleringMessage.toJson().also {
+        nyMelding(aktørId, fødselsnummer, organisasjonsnummer, "annullering", verdier)
+    }
+
+    private fun nyMelding(aktørId: String, fødselsnummer: String, organisasjonsnummer: String, eventName: String, verdier: Map<String, Any>) {
+        JsonMessage.newMessage(eventName, verdier).toJson().also {
+            rapidsConnection.publish(fødselsnummer, it)
             sikkerlogg.info(
-                "sender annullering for {}, {}\n\t$it",
+                "sender $eventName for {}, {}, {}\n\t$it",
+                keyValue("aktørId", aktørId),
                 keyValue("fødselsnummer", fødselsnummer),
                 keyValue("organisasjonsnummer", organisasjonsnummer)
             )
-        })
+        }
     }
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/overstyring/OverstyrTidslinje.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/overstyring/OverstyrTidslinje.kt
@@ -1,0 +1,45 @@
+package no.nav.helse.spesialist.api.overstyring
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.time.LocalDate
+import java.util.UUID
+import no.nav.helse.spesialist.api.saksbehandler.Saksbehandler
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerHendelse
+
+@JsonIgnoreProperties
+class OverstyrTidslinje(
+    private val aktørId: String,
+    private val fødselsnummer: String,
+    private val organisasjonsnummer: String,
+    private val begrunnelse: String,
+    private val dager: List<Overstyringdag>,
+    private val saksbehandlerOid: UUID
+): SaksbehandlerHendelse {
+    @JsonIgnoreProperties
+    class Overstyringdag(
+        val dato: LocalDate,
+        val type: String,
+        val fraType: String,
+        val grad: Int?,
+        val fraGrad: Int?
+    ) {
+        fun toJson(): Map<String, Any> {
+            return mutableMapOf<String, Any>(
+                "dato" to dato,
+                "type" to type,
+                "fraType" to fraType
+            ).apply {
+                compute("grad") { _, _ -> grad }
+                compute("fraGrad") { _, _ -> fraGrad }
+            }
+        }
+    }
+
+    override fun tellernavn(): String = "overstyr_tidslinje"
+
+    override fun saksbehandlerOid(): UUID = saksbehandlerOid
+
+    override fun håndter(saksbehandler: Saksbehandler) {
+        saksbehandler.overstyrTidslinje(aktørId, fødselsnummer, organisasjonsnummer, dager, begrunnelse)
+    }
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/Saksbehandler.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/Saksbehandler.kt
@@ -2,6 +2,7 @@ package no.nav.helse.spesialist.api.saksbehandler
 
 import io.ktor.server.auth.jwt.JWTPrincipal
 import java.util.UUID
+import no.nav.helse.spesialist.api.overstyring.OverstyrTidslinje.Overstyringdag
 
 class Saksbehandler(
     private val epostadresse: String,
@@ -36,12 +37,25 @@ class Saksbehandler(
         }
     }
 
+    internal fun overstyrTidslinje(
+        aktørId: String,
+        fødselsnummer: String,
+        organisasjonsnummer: String,
+        dager: List<Overstyringdag>,
+        begrunnelse: String,
+    ) {
+        observere.notify {
+            overstyrTidslinjeEvent(aktørId, fødselsnummer, organisasjonsnummer, json(), begrunnelse, dager)
+        }
+    }
+
     private fun List<SaksbehandlerObserver>.notify(hendelse: SaksbehandlerObserver.() -> Unit) {
         forEach { it.hendelse() }
     }
 
     private fun json() = mapOf(
         "epostaddresse" to epostadresse,
+        "epost" to epostadresse,
         "oid" to oid,
         "navn" to navn,
         "ident" to ident,

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/Saksbehandler.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/Saksbehandler.kt
@@ -40,7 +40,7 @@ class Saksbehandler(
         forEach { it.hendelse() }
     }
 
-    fun json() = mapOf(
+    private fun json() = mapOf(
         "epostaddresse" to epostadresse,
         "oid" to oid,
         "navn" to navn,
@@ -48,4 +48,20 @@ class Saksbehandler(
     )
 
     fun toDto() = SaksbehandlerDto(oid = oid, navn = navn, epost = epostadresse, ident = ident)
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is Saksbehandler &&
+                epostadresse == other.epostadresse &&
+                oid == other.oid &&
+                navn == other.navn &&
+                ident == other.ident)
+
+    override fun hashCode(): Int {
+        var result = epostadresse.hashCode()
+        result = 31 * result + oid.hashCode()
+        result = 31 * result + navn.hashCode()
+        result = 31 * result + ident.hashCode()
+        result = 31 * result + observere.hashCode()
+        return result
+    }
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDao.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDao.kt
@@ -31,4 +31,24 @@ class SaksbehandlerDao(dataSource: DataSource): HelseDao(dataSource) {
                 epost = row.string("epost"),
                 ident = row.string("ident"))}
 
+    internal fun finnSaksbehandlerFor(oid: UUID): Saksbehandler? {
+        return queryize("SELECT * FROM saksbehandler WHERE oid = :oid").single(mapOf("oid" to oid)) {
+            Saksbehandler(
+                it.string("epost"),
+                it.uuid("oid"),
+                it.string("navn"),
+                it.string("ident")
+            )
+        }
+    }
+
+    internal fun opprettFra(saksbehandlerDto: SaksbehandlerDto): Saksbehandler {
+        val epostadresse = saksbehandlerDto.epost
+        val oid = saksbehandlerDto.oid
+        val navn = saksbehandlerDto.navn
+        val ident = saksbehandlerDto.ident
+
+        opprettSaksbehandler(oid, navn, epostadresse, ident)
+        return Saksbehandler(epostadresse, oid, navn, ident)
+    }
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDto.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDto.kt
@@ -1,10 +1,20 @@
 package no.nav.helse.spesialist.api.saksbehandler
 
-import java.util.*
+import io.ktor.server.auth.jwt.JWTPrincipal
+import java.util.UUID
 
 data class SaksbehandlerDto(
     val oid: UUID,
     val navn: String,
     val epost: String,
     val ident: String
-)
+) {
+    companion object {
+        fun fraOnBehalfOfToken(jwtPrincipal: JWTPrincipal) = SaksbehandlerDto(
+            oid = jwtPrincipal.payload.getClaim("oid").asString().let { UUID.fromString(it) },
+            navn = jwtPrincipal.payload.getClaim("name").asString(),
+            epost = jwtPrincipal.payload.getClaim("preferred_username").asString(),
+            ident = jwtPrincipal.payload.getClaim("NAVident").asString(),
+        )
+    }
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerHendelse.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerHendelse.kt
@@ -1,0 +1,9 @@
+package no.nav.helse.spesialist.api.saksbehandler
+
+import java.util.UUID
+
+internal interface SaksbehandlerHendelse {
+    fun tellernavn(): String
+    fun saksbehandlerOid(): UUID
+    fun håndter(saksbehandler: Saksbehandler)
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerObserver.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerObserver.kt
@@ -1,5 +1,7 @@
 package no.nav.helse.spesialist.api.saksbehandler
 
+import no.nav.helse.spesialist.api.overstyring.OverstyrTidslinje
+
 internal interface SaksbehandlerObserver {
     fun annulleringEvent(
         aktørId: String,
@@ -9,5 +11,14 @@ internal interface SaksbehandlerObserver {
         fagsystemId: String,
         begrunnelser: List<String>,
         kommentar: String?
+    ) {}
+
+    fun overstyrTidslinjeEvent(
+        aktørId: String,
+        fødselsnummer: String,
+        organisasjonsnummer: String,
+        saksbehandler: Map<String, Any>,
+        begrunnelse: String,
+        dager: List<OverstyrTidslinje.Overstyringdag>
     ) {}
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerObserver.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerObserver.kt
@@ -1,0 +1,13 @@
+package no.nav.helse.spesialist.api.saksbehandler
+
+internal interface SaksbehandlerObserver {
+    fun annulleringEvent(
+        aktørId: String,
+        fødselsnummer: String,
+        organisasjonsnummer: String,
+        saksbehandler: Map<String, Any>,
+        fagsystemId: String,
+        begrunnelser: List<String>,
+        kommentar: String?
+    ) {}
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
@@ -3,6 +3,7 @@ package no.nav.helse.spesialist.api.utbetaling
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.util.UUID
 import no.nav.helse.spesialist.api.saksbehandler.Saksbehandler
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerHendelse
 
 @JsonIgnoreProperties
 data class Annullering(
@@ -23,8 +24,3 @@ data class Annullering(
     }
 }
 
-internal sealed interface SaksbehandlerHendelse {
-    fun tellernavn(): String
-    fun saksbehandlerOid(): UUID
-    fun håndter(saksbehandler: Saksbehandler)
-}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
@@ -23,4 +23,3 @@ data class Annullering(
         saksbehandler.annuller(aktørId, fødselsnummer, organisasjonsnummer, fagsystemId, begrunnelser, kommentar)
     }
 }
-

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/Annullering.kt
@@ -1,14 +1,30 @@
 package no.nav.helse.spesialist.api.utbetaling
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.util.UUID
+import no.nav.helse.spesialist.api.saksbehandler.Saksbehandler
 
 @JsonIgnoreProperties
-data class AnnulleringDto(
-    val aktørId: String,
-    val fødselsnummer: String,
-    val organisasjonsnummer: String,
-    val fagsystemId: String,
-    val saksbehandlerIdent: String,
-    val begrunnelser: List<String> = emptyList(),
-    val kommentar: String?
-)
+data class Annullering(
+    private val aktørId: String,
+    private val fødselsnummer: String,
+    private val organisasjonsnummer: String,
+    private val fagsystemId: String,
+    private val saksbehandlerIdent: String,
+    private val begrunnelser: List<String> = emptyList(),
+    private val kommentar: String?,
+    private val saksbehandlerOid: UUID
+) : SaksbehandlerHendelse {
+    override fun tellernavn(): String = "annulleringer"
+    override fun saksbehandlerOid(): UUID = saksbehandlerOid
+
+    override fun håndter(saksbehandler: Saksbehandler) {
+        saksbehandler.annuller(aktørId, fødselsnummer, organisasjonsnummer, fagsystemId, begrunnelser, kommentar)
+    }
+}
+
+internal sealed interface SaksbehandlerHendelse {
+    fun tellernavn(): String
+    fun saksbehandlerOid(): UUID
+    fun håndter(saksbehandler: Saksbehandler)
+}

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/AnnulleringApi.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/AnnulleringApi.kt
@@ -7,12 +7,16 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import no.nav.helse.spesialist.api.SaksbehandlerMediator
-import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto.Companion.fraOnBehalfOfToken
 
 fun Route.annulleringApi(saksbehandlerMediator: SaksbehandlerMediator) {
     post("/api/annullering") {
-        saksbehandlerMediator.håndter(call.receive<Annullering>(), SaksbehandlerDto.fraOnBehalfOfToken(requireNotNull(call.principal())))
+        withContext(Dispatchers.IO) {
+            saksbehandlerMediator.håndter(call.receive<Annullering>(), fraOnBehalfOfToken(requireNotNull(call.principal())))
+        }
         call.respond(HttpStatusCode.OK, mapOf("status" to "OK"))
     }
 }

--- a/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/AnnulleringApi.kt
+++ b/spesialist-api/src/main/kotlin/no/nav/helse/spesialist/api/utbetaling/AnnulleringApi.kt
@@ -8,14 +8,11 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.nav.helse.spesialist.api.SaksbehandlerMediator
-import no.nav.helse.spesialist.api.saksbehandler.Saksbehandler
+import no.nav.helse.spesialist.api.saksbehandler.SaksbehandlerDto
 
 fun Route.annulleringApi(saksbehandlerMediator: SaksbehandlerMediator) {
     post("/api/annullering") {
-        val annullering = call.receive<AnnulleringDto>()
-        val saksbehandler = Saksbehandler.fraOnBehalfOfToken(requireNotNull(call.principal()))
-
-        saksbehandlerMediator.håndter(annullering, saksbehandler)
+        saksbehandlerMediator.håndter(call.receive<Annullering>(), SaksbehandlerDto.fraOnBehalfOfToken(requireNotNull(call.principal())))
         call.respond(HttpStatusCode.OK, mapOf("status" to "OK"))
     }
 }

--- a/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/DatabaseIntegrationTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/DatabaseIntegrationTest.kt
@@ -60,7 +60,7 @@ internal abstract class DatabaseIntegrationTest : AbstractDatabaseTest() {
         val ENHET = Enhet(101, "Halden")
         val PERIODE = Periode(UUID.randomUUID(), LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 31))
         val ARBEIDSFORHOLD = Arbeidsforhold(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 2), "EN TITTEL", 100)
-        val SAKSBEHANDLER = Saksbehandler(UUID.randomUUID(), "Jan Banan", "jan.banan@nav.no", "B123456")
+        val SAKSBEHANDLER = Testsaksbehandler(UUID.randomUUID(), "Jan Banan", "jan.banan@nav.no", "B123456")
 
         const val FØDSELSNUMMER = "01017011111"
         const val AKTØRID = "01017011111111"
@@ -642,7 +642,7 @@ internal abstract class DatabaseIntegrationTest : AbstractDatabaseTest() {
         val prosent: Int,
     )
 
-    protected data class Saksbehandler(
+    protected data class Testsaksbehandler(
         val oid: UUID,
         val navn: String,
         val ident: String,

--- a/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDaoTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerDaoTest.kt
@@ -1,9 +1,10 @@
-package no.nav.helse.modell.saksbehandler
+package no.nav.helse.spesialist.api.saksbehandler
 
-import DatabaseIntegrationTest
 import java.util.UUID
+import no.nav.helse.spesialist.api.DatabaseIntegrationTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 internal class SaksbehandlerDaoTest : DatabaseIntegrationTest() {
@@ -11,6 +12,10 @@ internal class SaksbehandlerDaoTest : DatabaseIntegrationTest() {
     private companion object {
         private const val IS_UPDATED = 1
         private const val IS_NOT_UPDATED = 0
+        private val SAKSBEHANDLER_OID = UUID.randomUUID()
+        private const val SAKSBEHANDLEREPOST = "saksbehandlerepost@nav.no"
+        private const val SAKSBEHANDLER_IDENT = "S123456"
+        private const val SAKSBEHANDLER_NAVN = "Fornavn Mellomnavn Etternavn"
     }
 
     @Test
@@ -51,6 +56,20 @@ internal class SaksbehandlerDaoTest : DatabaseIntegrationTest() {
         saksbehandlerDao.opprettSaksbehandler(SAKSBEHANDLER_OID, SAKSBEHANDLER_NAVN, SAKSBEHANDLEREPOST, SAKSBEHANDLER_IDENT)
         val saksbehandler = saksbehandlerDao.finnSaksbehandler(SAKSBEHANDLEREPOST)
         assertNotNull(saksbehandler)
+    }
+
+    @Test
+    fun `finner ikke noen saksbehandler hvis det ikke finnes noen`() {
+        val saksbehandler = saksbehandlerDao.finnSaksbehandlerFor(UUID.randomUUID())
+        assertNull(saksbehandler)
+    }
+
+    @Test
+    fun `henter ut saksbehandler vha oid`() {
+        saksbehandlerDao.opprettSaksbehandler(SAKSBEHANDLER_OID, SAKSBEHANDLER_NAVN, SAKSBEHANDLEREPOST, SAKSBEHANDLER_IDENT)
+        val saksbehandler = saksbehandlerDao.finnSaksbehandlerFor(SAKSBEHANDLER_OID)
+        assertNotNull(saksbehandler)
+        assertEquals(Saksbehandler(SAKSBEHANDLEREPOST, SAKSBEHANDLER_OID, SAKSBEHANDLER_NAVN, SAKSBEHANDLER_IDENT), saksbehandler)
     }
 
     @Test

--- a/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerTest.kt
@@ -1,0 +1,83 @@
+package no.nav.helse.spesialist.api.saksbehandler
+
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class SaksbehandlerTest {
+    private val oid = UUID.randomUUID()
+    private val saksbehandler get() = Saksbehandler("epost@nav.no", oid, "navn", "ident")
+    private val annulleringer = mutableListOf<String>()
+
+    @Test
+    fun `kan registrere observere`() {
+        saksbehandler.apply {
+            register(observer)
+            annuller("aktørId", "fødselsnummer", "organisasjonsnummer", "fagsystemId", true, emptyList(), null)
+        }
+        assertEquals(1, annulleringer.size)
+    }
+
+    @Test
+    fun `referential equals`() {
+        val saksbehandler = saksbehandler
+        assertEquals(saksbehandler, saksbehandler)
+        assertEquals(saksbehandler.hashCode(), saksbehandler.hashCode())
+    }
+
+    @Test
+    fun `structural equals`() {
+        val saksbehandler1 = saksbehandler
+        val saksbehandler2 = saksbehandler
+        assertEquals(saksbehandler1, saksbehandler2)
+        assertEquals(saksbehandler1.hashCode(), saksbehandler2.hashCode())
+    }
+
+    @Test
+    fun `forskjellig oid`() {
+        val enSaksbehandler = saksbehandler
+        val annenSaksbehandler = Saksbehandler("epost@nav.no", UUID.randomUUID(), "navn", "ident")
+        assertNotEquals(annenSaksbehandler, enSaksbehandler)
+        assertNotEquals(annenSaksbehandler.hashCode(), enSaksbehandler.hashCode())
+    }
+
+    @Test
+    fun `forskjellig epost`() {
+        val enSaksbehandler = saksbehandler
+        val annenSaksbehandler = Saksbehandler("annen_epost@nav.no", oid, "navn", "ident")
+        assertNotEquals(annenSaksbehandler, enSaksbehandler)
+        assertNotEquals(annenSaksbehandler.hashCode(), enSaksbehandler.hashCode())
+    }
+
+    @Test
+    fun `forskjellig navn`() {
+        val enSaksbehandler = saksbehandler
+        val annenSaksbehandler = Saksbehandler("epost@nav.no", oid, "annet navn", "ident")
+        assertNotEquals(annenSaksbehandler, enSaksbehandler)
+        assertNotEquals(annenSaksbehandler.hashCode(), enSaksbehandler.hashCode())
+    }
+
+    @Test
+    fun `forskjellig ident`() {
+        val enSaksbehandler = saksbehandler
+        val annenSaksbehandler = Saksbehandler("epost@nav.no", oid, "navn", "annen_ident")
+        assertNotEquals(annenSaksbehandler, enSaksbehandler)
+        assertNotEquals(annenSaksbehandler.hashCode(), enSaksbehandler.hashCode())
+    }
+
+    private val observer = object: SaksbehandlerObserver {
+        override fun annulleringEvent(
+            aktørId: String,
+            fødselsnummer: String,
+            organisasjonsnummer: String,
+            saksbehandler: Map<String, Any>,
+            fagsystemId: String,
+            begrunnelser: List<String>,
+            gjelderSisteSkjæringstidspunkt: Boolean,
+            kommentar: String?
+        ) {
+            annulleringer.add(fagsystemId)
+        }
+    }
+}

--- a/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerTest.kt
+++ b/spesialist-api/src/test/kotlin/no/nav/helse/spesialist/api/saksbehandler/SaksbehandlerTest.kt
@@ -14,7 +14,7 @@ class SaksbehandlerTest {
     fun `kan registrere observere`() {
         saksbehandler.apply {
             register(observer)
-            annuller("aktørId", "fødselsnummer", "organisasjonsnummer", "fagsystemId", true, emptyList(), null)
+            annuller("aktørId", "fødselsnummer", "organisasjonsnummer", "fagsystemId", emptyList(), null)
         }
         assertEquals(1, annulleringer.size)
     }
@@ -74,7 +74,6 @@ class SaksbehandlerTest {
             saksbehandler: Map<String, Any>,
             fagsystemId: String,
             begrunnelser: List<String>,
-            gjelderSisteSkjæringstidspunkt: Boolean,
             kommentar: String?
         ) {
             annulleringer.add(fagsystemId)

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/ApplicationBuilder.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/ApplicationBuilder.kt
@@ -308,7 +308,7 @@ internal class ApplicationBuilder(env: Map<String, String>) : RapidsConnection.S
                         oppgaveMediator = oppgaveMediator,
                         tilgangsgrupper = tilgangsgrupper,
                     )
-                    overstyringApi(hendelseMediator)
+                    overstyringApi(saksbehandlerMediator, hendelseMediator)
                     tildelingApi(tildelingService)
                     annulleringApi(saksbehandlerMediator)
                     opptegnelseApi(OpptegnelseMediator(opptegnelseApiDao, abonnementDao))

--- a/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringTidslinje.kt
+++ b/spesialist-selve/src/main/kotlin/no/nav/helse/mediator/meldinger/OverstyringTidslinje.kt
@@ -99,10 +99,7 @@ internal class OverstyringTidslinje(
                     it.requireKey("organisasjonsnummer")
                     it.requireKey("dager")
                     it.requireKey("@id")
-                    it.requireKey("saksbehandlerOid")
-                    it.requireKey("saksbehandlerNavn")
-                    it.requireKey("saksbehandlerIdent")
-                    it.requireKey("saksbehandlerEpost")
+                    it.requireKey("saksbehandler.oid", "saksbehandler.navn", "saksbehandler.epost", "saksbehandler.ident")
                     it.requireKey("begrunnelse")
                 }
             }.register(this)
@@ -122,10 +119,10 @@ internal class OverstyringTidslinje(
             mediator.overstyringTidslinje(
                 id = UUID.fromString(packet["@id"].asText()),
                 fødselsnummer = packet["fødselsnummer"].asText(),
-                oid = UUID.fromString(packet["saksbehandlerOid"].asText()),
-                navn = packet["saksbehandlerNavn"].asText(),
-                ident = packet["saksbehandlerIdent"].asText(),
-                epost = packet["saksbehandlerEpost"].asText(),
+                oid = UUID.fromString(packet["saksbehandler.oid"].asText()),
+                navn = packet["saksbehandler.navn"].asText(),
+                ident = packet["saksbehandler.ident"].asText(),
+                epost = packet["saksbehandler.epost"].asText(),
                 orgnummer = packet["organisasjonsnummer"].asText(),
                 begrunnelse = packet["begrunnelse"].asText(),
                 overstyrteDager = packet["dager"].toOverstyrteDagerDto(),

--- a/spesialist-selve/src/test/kotlin/AbstractE2ETest.kt
+++ b/spesialist-selve/src/test/kotlin/AbstractE2ETest.kt
@@ -69,6 +69,7 @@ import no.nav.helse.modell.vedtaksperiode.Periodetype
 import no.nav.helse.modell.vergemal.VergemålDao
 import no.nav.helse.rapids_rivers.asLocalDateTime
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.helse.spesialist.api.SaksbehandlerMediator
 import no.nav.helse.spesialist.api.SaksbehandlerTilganger
 import no.nav.helse.spesialist.api.abonnement.AbonnementDao
 import no.nav.helse.spesialist.api.arbeidsgiver.ArbeidsgiverApiDao
@@ -177,6 +178,8 @@ internal abstract class AbstractE2ETest : AbstractDatabaseTest() {
         oppgaveMediator = oppgaveMediator,
         hendelsefabrikk = hendelsefabrikk
     )
+
+    internal val saksbehandlerMediator = SaksbehandlerMediator(dataSource, testRapid)
 
     internal val dataFetchingEnvironment = mockk<DataFetchingEnvironment>(relaxed = true)
 

--- a/spesialist-selve/src/test/kotlin/TestmeldingsfabrikkV2.kt
+++ b/spesialist-selve/src/test/kotlin/TestmeldingsfabrikkV2.kt
@@ -492,10 +492,12 @@ internal object TestmeldingsfabrikkV2 {
             "organisasjonsnummer" to organisasjonsnummer,
             "dager" to dager,
             "begrunnelse" to begrunnelse,
-            "saksbehandlerOid" to saksbehandleroid,
-            "saksbehandlerIdent" to saksbehandlerident,
-            "saksbehandlerNavn" to saksbehandlernavn,
-            "saksbehandlerEpost" to saksbehandlerepost
+            "saksbehandler" to mapOf(
+                "oid" to saksbehandleroid,
+                "navn" to saksbehandlernavn,
+                "ident" to saksbehandlerident,
+                "epost" to saksbehandlerepost
+            ),
         )
     )
 

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/api/AbstractApiTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/api/AbstractApiTest.kt
@@ -60,11 +60,11 @@ abstract class AbstractApiTest {
                 "Authorization",
                 "Bearer ${
                     jwtStub.getToken(
-                        listOfNotNull(requiredGroup.toString(), group),
-                        oid.toString(),
-                        epostadresse,
-                        clientId,
-                        issuer
+                        groups = listOfNotNull(requiredGroup.toString(), group),
+                        oid = oid.toString(),
+                        epostadresse = epostadresse,
+                        clientId = clientId,
+                        issuer = issuer
                     )
                 }"
             )

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/api/OverstyringApiTest.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/api/OverstyringApiTest.kt
@@ -35,7 +35,6 @@ import no.nav.helse.mediator.api.AbstractApiTest.Companion.authentication
 import no.nav.helse.mediator.api.AbstractApiTest.Companion.azureAdAppConfig
 import no.nav.helse.rapids_rivers.asLocalDate
 import no.nav.helse.spesialist.api.azureAdAppAuthentication
-import no.nav.helse.spesialist.api.overstyring.OverstyrTidslinje
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -85,29 +84,36 @@ internal class OverstyringApiTest : AbstractE2ETest() {
 
     @Test
     fun `overstyr tidslinje til arbeidsdag`() {
-        with(TestApplicationEngine()) {
-            setUpApplication()
-            val overstyring = OverstyrTidslinje(
-                organisasjonsnummer = ORGNR,
-                fødselsnummer = FØDSELSNUMMER,
-                aktørId = AKTØR,
-                begrunnelse = "en begrunnelse",
-                saksbehandlerOid = SAKSBEHANDLER_OID,
-                dager = listOf(
-                    OverstyrTidslinje.Overstyringdag(dato = 10.januar, type = "Arbeidsdag", fraType = "Sykedag", grad = null, fraGrad = 100)
-                )
-            )
+        testApplication {
 
-            val response = runBlocking {
-                client.post("/api/overstyr/dager") {
-                    header(HttpHeaders.ContentType, "application/json")
+            val response = execute {
+                post("/api/overstyr/dager") {
+                    contentType(ContentType.Application.Json)
+                    accept(ContentType.Application.Json)
                     authentication(
                         oid = SAKSBEHANDLER_OID,
                         epost = SAKSBEHANDLER_EPOST,
                         navn = SAKSBEHANDLER_NAVN,
                         ident = SAKSBEHANDLER_IDENT
                     )
-                    setBody(objectMapper.writeValueAsString(overstyring))
+                    setBody(
+                        mapOf(
+                            "aktørId" to AKTØR,
+                            "fødselsnummer" to FØDSELSNUMMER,
+                            "organisasjonsnummer" to ORGNR,
+                            "begrunnelse" to "en begrunnelse",
+                            "dager" to listOf(
+                                mapOf(
+                                    "dato" to 10.januar,
+                                    "type" to "Arbeidsdag",
+                                    "fraType" to "Sykedag",
+                                    "grad" to null,
+                                    "fraGrad" to 100
+                                )
+                            ),
+                            "saksbehandlerOid" to SAKSBEHANDLER_OID
+                        )
+                    )
                 }
             }
 
@@ -118,29 +124,35 @@ internal class OverstyringApiTest : AbstractE2ETest() {
 
     @Test
     fun `overstyr tidslinje fra arbeidsdag`() {
-        with(TestApplicationEngine()) {
-            setUpApplication()
-            val overstyring = OverstyrTidslinje(
-                organisasjonsnummer = ORGNR,
-                fødselsnummer = FØDSELSNUMMER,
-                aktørId = AKTØR,
-                begrunnelse = "en begrunnelse",
-                saksbehandlerOid = SAKSBEHANDLER_OID,
-                dager = listOf(
-                    OverstyrTidslinje.Overstyringdag(dato = 10.januar, type = "Sykedag", fraType = "Arbeidsdag", grad = null, fraGrad = 100)
-                )
-            )
-
-            val response = runBlocking {
-                client.post("/api/overstyr/dager") {
-                    header(HttpHeaders.ContentType, "application/json")
+        testApplication {
+            val response = execute {
+                post("/api/overstyr/dager") {
+                    contentType(ContentType.Application.Json)
+                    accept(ContentType.Application.Json)
                     authentication(
                         oid = SAKSBEHANDLER_OID,
                         epost = SAKSBEHANDLER_EPOST,
                         navn = SAKSBEHANDLER_NAVN,
                         ident = SAKSBEHANDLER_IDENT
                     )
-                    setBody(objectMapper.writeValueAsString(overstyring))
+                    setBody(
+                        mapOf(
+                            "aktørId" to AKTØR,
+                            "fødselsnummer" to FØDSELSNUMMER,
+                            "organisasjonsnummer" to ORGNR,
+                            "begrunnelse" to "en begrunnelse",
+                            "dager" to listOf(
+                                mapOf(
+                                    "dato" to 10.januar,
+                                    "type" to "Sykedag",
+                                    "fraType" to "Arbeidsdag",
+                                    "grad" to null,
+                                    "fraGrad" to 100
+                                )
+                            ),
+                            "saksbehandlerOid" to SAKSBEHANDLER_OID
+                        )
+                    )
                 }
             }
 

--- a/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/Testmeldingfabrikk.kt
+++ b/spesialist-selve/src/test/kotlin/no/nav/helse/mediator/meldinger/Testmeldingfabrikk.kt
@@ -575,10 +575,12 @@ internal class Testmeldingfabrikk(private val fødselsnummer: String, private va
             "organisasjonsnummer" to organisasjonsnummer,
             "dager" to dager,
             "begrunnelse" to begrunnelse,
-            "saksbehandlerOid" to saksbehandleroid,
-            "saksbehandlerIdent" to saksbehandlerident,
-            "saksbehandlerNavn" to saksbehandlernavn,
-            "saksbehandlerEpost" to saksbehandlerepost
+            "saksbehandler" to mapOf(
+                "oid" to saksbehandleroid,
+                "navn" to saksbehandlernavn,
+                "epost" to saksbehandlerepost,
+                "ident" to saksbehandlerident
+            )
         )
     )
 


### PR DESCRIPTION
**NB: Kan ikke merges før annulleringer inneholder saksbehandleroid når de sendes fra Speil**

Idé: samle oppførsel som gjøres til dels likt og til dels ulikt (men som burde være likt) i de ulike endepunktene, og delegere håndteringen til et Saksbehandler-objekt.

Fordeler: 
Vi kan standarisere en del oppførsel, eksempelvis:
* Logger alltid når en saksbehandler gjør en handling
* Teller alle handlinger en saksbehandler gjør

Vi kan videre her bygge på med at hendelsene//handlingene selv sier hvilke tilganger de krever for å kunne utføres, og sånn sett forene håndtering av tilgangsstyring på handlinger, fremfor slik det er gjort nå, der dette håndteres flere steder.